### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://secure.travis-ci.org/toyama0919/fluent-plugin-split.png?branch=master)](http://travis-ci.org/toyama0919/fluent-plugin-split)
 
-# fluent-plugin-split
+# fluent-plugin-split, a plugin for [Fluentd](http://fluentd.org)
 
 Output Split String Plugin for fluentd
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
