### PR TITLE
Tweak for v0.14 Compatibile layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
+  - 2.1
+  - 2.2
+  - 2.3.4
+  - 2.4.1
 gemfile:
   - Gemfile
 script: "rake spec"

--- a/fluent-plugin-split.gemspec
+++ b/fluent-plugin-split.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "spork"
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "test-unit", "~> 3.2"
 
 end

--- a/lib/fluent/plugin/out_split.rb
+++ b/lib/fluent/plugin/out_split.rb
@@ -47,10 +47,11 @@ module Fluent
           router.emit(output_tag, time, result)
         end
       end
-      chain.next
     rescue => e
       log.warn e.message
       log.warn e.backtrace.join(', ')
+    ensure
+      chain.next
     end
   end
 end

--- a/lib/fluent/plugin/out_split.rb
+++ b/lib/fluent/plugin/out_split.rb
@@ -3,6 +3,11 @@ module Fluent
   class SplitOutput < Output
     Fluent::Plugin.register_output('split', self)
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     def initialize
       super
     end
@@ -35,7 +40,7 @@ module Fluent
           record.each do|key, value|
             result[key] = value if @keep_keys_array.include?(key)
           end
-          Engine.emit(output_tag, time, result)
+          router.emit(output_tag, time, result)
         end
       end
       chain.next

--- a/lib/fluent/plugin/out_split.rb
+++ b/lib/fluent/plugin/out_split.rb
@@ -8,6 +8,10 @@ module Fluent
       define_method("router") { Fluent::Engine }
     end
 
+    unless method_defined?(:log)
+      define_method(:log) { $log }
+    end
+
     def initialize
       super
     end
@@ -45,8 +49,8 @@ module Fluent
       end
       chain.next
     rescue => e
-      $log.warn e.message
-      $log.warn e.backtrace.join(', ')
+      log.warn e.message
+      log.warn e.backtrace.join(', ')
     end
   end
 end


### PR DESCRIPTION
I've found that this plugin is not ready to work with Fluentd v0.14 Compatible layer.
I tried to be able to run test cases with Fluentd v0.14.

Could you check these patches?

Thanks in advance.