### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-split.gemspec
+++ b/fluent-plugin-split.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"

--- a/lib/fluent/plugin/out_split.rb
+++ b/lib/fluent/plugin/out_split.rb
@@ -8,19 +8,6 @@ module Fluent::Plugin
 
     helpers :event_emitter
 
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
-    def initialize
-      super
-    end
-
     config_param :output_tag, :string
     config_param :output_key, :string
     config_param :format, :string, default: 'csv'

--- a/lib/fluent/plugin/out_split.rb
+++ b/lib/fluent/plugin/out_split.rb
@@ -1,7 +1,12 @@
 # -*- encoding : utf-8 -*-
-module Fluent
+
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
   class SplitOutput < Output
     Fluent::Plugin.register_output('split', self)
+
+    helpers :event_emitter
 
     # Define `router` method of v0.12 to support v0.10 or earlier
     unless method_defined?(:router)
@@ -36,7 +41,7 @@ module Fluent
       end
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       es.each do |time, record|
         next if record[@key_name].nil?
         record[@key_name].split(@separator).each do|item|
@@ -50,8 +55,6 @@ module Fluent
     rescue => e
       log.warn e.message
       log.warn e.backtrace.join(', ')
-    ensure
-      chain.next
     end
   end
 end

--- a/spec/out_split_spec.rb
+++ b/spec/out_split_spec.rb
@@ -6,8 +6,8 @@ class SplitOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
-  def create_driver(conf = CONFIG, tag = 'test')
-    d = Fluent::Test::OutputTestDriver.new(Fluent::SplitOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    d = Fluent::Test::Driver::Output.new(Fluent::Plugin::SplitOutput).configure(conf)
     d
   end
 
@@ -78,14 +78,14 @@ class SplitOutputTest < Test::Unit::TestCase
       format csv
       key_name keywords
       keep_keys site
-    ], "test.split"
+    ]
 
-    time = Time.now.to_i
-    d.run {
-      d.emit({"keywords"=>"keyword1,keyword2,keyword3", "site" => "google", "user_id" => "1"}, time)
+    time = event_time
+    d.run(default_tag: "test.split") {
+      d.feed(time, {"keywords"=>"keyword1,keyword2,keyword3", "site" => "google", "user_id" => "1"})
     }
     assert_equal [[tag, time, {"keyword"=>"keyword1", "site"=>"google"}],
                   [tag, time, {"keyword"=>"keyword2", "site"=>"google"}],
-                  [tag, time, {"keyword"=>"keyword3", "site"=>"google"}]], d.emits
+                  [tag, time, {"keyword"=>"keyword3", "site"=>"google"}]], d.events
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 unless ENV.key?('VERBOSE')
   nulllogger = Object.new
   nulllogger.instance_eval do|obj|
@@ -25,4 +27,5 @@ end
 require 'fluent/plugin/out_split'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end


### PR DESCRIPTION
Please take a look after #2 is merged.

---

I've tried to migrate to use v0.14 Input Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.